### PR TITLE
chore: fix skill frontmatter and enable plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Commit with convention. Use when committing changes — enforces type/scope/subject format and PR workflow.
-user_invocable: true
+user-invokable: true
 ---
 
 # Commit — Strata Commit Convention


### PR DESCRIPTION
## Summary
- Fix `user_invocable` → `user-invokable` attribute in commit skill
- Enable `frontend-design` and `context7` plugins via project settings

## Test plan
- [ ] No skill warning on session start
- [ ] Plugins load after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)