### PR TITLE
chore(ci): skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.claude/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.claude/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to CI workflow for `**/*.md`, `LICENSE`, `.claude/**`
- Docs-only and AI config changes no longer trigger the full lint → test → build pipeline
- Saves CI minutes and unblocks documentation PRs from unrelated failures

## Test plan
- [ ] Push a `.md`-only change and verify CI does not trigger
- [ ] Push a `.tsx` change and verify CI still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)