### PR TITLE
feat(tokens): add motion token system with reduced-motion gate

### DIFF
--- a/src/components/disclosure/Accordion/Accordion.tsx
+++ b/src/components/disclosure/Accordion/Accordion.tsx
@@ -54,7 +54,7 @@ export function AccordionTrigger({
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="h-4 w-4 shrink-0 transition-transform duration-200 data-[state=open]:rotate-180"
+          className="h-4 w-4 shrink-0 transition-transform duration-[--motion-duration-entrance] data-[state=open]:rotate-180"
           aria-hidden="true"
         >
           <path d="m6 9 6 6 6-6" />
@@ -77,7 +77,8 @@ export function AccordionContent({
       ref={ref}
       className={cn(
         'overflow-hidden text-sm',
-        'data-[state=open]:animate-[accordion-down_200ms] data-[state=closed]:animate-[accordion-up_200ms]',
+        'data-[state=open]:animate-[accordion-down_var(--motion-duration-entrance)_var(--motion-ease-entrance)]',
+        'data-[state=closed]:animate-[accordion-up_var(--motion-duration-exit)_var(--motion-ease-exit)]',
         className,
       )}
       {...props}

--- a/src/components/disclosure/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/disclosure/NavigationMenu/NavigationMenu.tsx
@@ -77,7 +77,7 @@ export function NavigationMenuTrigger({
         height="16"
         viewBox="0 0 16 16"
         fill="none"
-        className="relative top-px transition-transform duration-200 data-[state=open]:rotate-180 group-data-[state=open]:rotate-180"
+        className="relative top-px transition-transform duration-[--motion-duration-entrance] data-[state=open]:rotate-180 group-data-[state=open]:rotate-180"
       >
         <path
           d="M4 6l4 4 4-4"

--- a/src/components/layout/Sidebar/Sidebar.tsx
+++ b/src/components/layout/Sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ export function Sidebar({
   return (
     <aside
       className={cn(
-        'flex flex-col bg-[--sidebar-bg] border-r border-[--sidebar-border] transition-[width] duration-200',
+        'flex flex-col bg-[--sidebar-bg] border-r border-[--sidebar-border] transition-[width] duration-[--motion-duration-entrance]',
         collapsed ? 'overflow-hidden' : 'overflow-y-auto',
         className,
       )}

--- a/src/components/primitives/Button/Button.variant.ts
+++ b/src/components/primitives/Button/Button.variant.ts
@@ -4,7 +4,7 @@ export const buttonVariants = cva(
   [
     'inline-flex items-center justify-center font-medium',
     'rounded-[--btn-radius]',
-    'transition-colors duration-150',
+    'transition-colors duration-[--motion-duration-normal]',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--border-interactive]',
     'disabled:pointer-events-none disabled:opacity-40',
   ],

--- a/src/components/primitives/Card/Card.tsx
+++ b/src/components/primitives/Card/Card.tsx
@@ -9,7 +9,7 @@ const VARIANT_MAP: Record<CardVariant, string> = {
   interactive: [
     'bg-[--card-bg] border border-[--card-border] rounded-[--card-radius]',
     'hover:bg-[--card-bg-hover] hover:border-[--card-border-hover]',
-    'cursor-pointer transition-colors duration-150',
+    'cursor-pointer transition-colors duration-[--motion-duration-normal]',
   ].join(' '),
 };
 

--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@ export function Checkbox({ className, ref, ...props }: CheckboxProps) {
         'h-4 w-4 shrink-0 rounded-[--checkbox-radius]',
         'border border-[--checkbox-border] bg-[--checkbox-bg]',
         'data-[state=checked]:bg-[--checkbox-bg-checked] data-[state=checked]:border-[--checkbox-border-checked]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--border-interactive]',
         'disabled:pointer-events-none disabled:opacity-40',
         className,

--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -32,7 +32,7 @@ export function Input({
         'w-full rounded-[--input-radius]',
         'bg-[--input-bg] text-[--input-fg] border border-[--input-border]',
         'placeholder:text-[--input-placeholder]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus:outline-none focus:ring-2 focus:ring-[--input-ring] focus:border-[--input-border-focus]',
         'disabled:pointer-events-none disabled:opacity-40',
         error && 'border-[--input-border-error]',

--- a/src/components/primitives/ProgressBar/ProgressBar.tsx
+++ b/src/components/primitives/ProgressBar/ProgressBar.tsx
@@ -35,7 +35,7 @@ export function ProgressBar({
       )}
     >
       <ProgressPrimitive.Indicator
-        className="h-full rounded-full bg-[--progress-bar] transition-transform duration-300"
+        className="h-full rounded-full bg-[--progress-bar] transition-transform duration-[--motion-duration-slow]"
         style={{ transform: `translateX(-${100 - percentage}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/components/primitives/RadioGroup/RadioGroup.tsx
+++ b/src/components/primitives/RadioGroup/RadioGroup.tsx
@@ -40,7 +40,7 @@ export function RadioGroupItem({
         'h-4 w-4 shrink-0 rounded-full',
         'border border-[--checkbox-border] bg-transparent',
         'data-[state=checked]:border-[--checkbox-border-checked]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--border-interactive]',
         'disabled:pointer-events-none disabled:opacity-40',
         className,

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -34,7 +34,7 @@ export function SelectTrigger({
         'rounded-[--select-radius]',
         'border border-[--select-border] bg-[--select-bg] px-3 text-sm text-[--select-fg]',
         'placeholder:text-[--select-placeholder]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus:outline-none focus:ring-2 focus:ring-[--select-border-focus]',
         'disabled:pointer-events-none disabled:opacity-40',
         className,

--- a/src/components/primitives/Slider/Slider.tsx
+++ b/src/components/primitives/Slider/Slider.tsx
@@ -26,7 +26,7 @@ export function Slider({ className, ref, ...props }: SliderProps) {
             'block h-4 w-4 rounded-full',
             'bg-[--slider-thumb] border-2 border-[--slider-range]',
             'shadow-sm',
-            'transition-colors duration-150',
+            'transition-colors duration-[--motion-duration-normal]',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--border-interactive]',
           )}
         />

--- a/src/components/primitives/Switch/Switch.tsx
+++ b/src/components/primitives/Switch/Switch.tsx
@@ -30,7 +30,7 @@ export function Switch({ size = 'md', className, ref, ...props }: SwitchProps) {
         'inline-flex shrink-0 items-center rounded-full',
         'bg-[--switch-bg]',
         'data-[state=checked]:bg-[--switch-bg-checked]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--border-interactive]',
         'disabled:pointer-events-none disabled:opacity-40',
         SIZE_MAP[size].root,
@@ -41,7 +41,7 @@ export function Switch({ size = 'md', className, ref, ...props }: SwitchProps) {
       <SwitchPrimitive.Thumb
         className={cn(
           'block rounded-full bg-[--switch-thumb]',
-          'transition-transform duration-150',
+          'transition-transform duration-[--motion-duration-normal]',
           'data-[state=unchecked]:translate-x-0.5',
           SIZE_MAP[size].thumb,
         )}

--- a/src/components/primitives/Textarea/Textarea.tsx
+++ b/src/components/primitives/Textarea/Textarea.tsx
@@ -35,7 +35,7 @@ export function Textarea({
         'w-full min-h-[80px] rounded-[--input-radius]',
         'bg-[--input-bg] text-[--input-fg] border border-[--input-border]',
         'placeholder:text-[--input-placeholder]',
-        'transition-colors duration-150',
+        'transition-colors duration-[--motion-duration-normal]',
         'focus:outline-none focus:ring-2 focus:ring-[--input-ring] focus:border-[--input-border-focus]',
         'disabled:pointer-events-none disabled:opacity-40',
         'resize-y',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+/**
+ * Detects `prefers-reduced-motion: reduce` for JS-driven animations.
+ *
+ * CSS transitions/animations are handled globally via the motion token
+ * gate in layer1-primitive.css. This hook covers rAF-based animations
+ * that bypass CSS (per ADR global-css-motion-gate).
+ */
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/tokens/layer1-primitive.css
+++ b/src/tokens/layer1-primitive.css
@@ -95,6 +95,21 @@
   --sp-text-3xl: 1.875rem;
   --sp-text-4xl: 2.25rem;
 
+  /* ── Motion scale ──────────────────────────────────────────── */
+  --sp-duration-0: 0ms;
+  --sp-duration-75: 75ms;
+  --sp-duration-100: 100ms;
+  --sp-duration-150: 150ms;
+  --sp-duration-200: 200ms;
+  --sp-duration-300: 300ms;
+  --sp-duration-500: 500ms;
+
+  --sp-ease-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --sp-ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --sp-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --sp-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --sp-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
   /* ── Radius scale ──────────────────────────────────────────── */
   --sp-radius-none: 0;
   --sp-radius-sm: 0.25rem;

--- a/src/tokens/layer2-semantic.css
+++ b/src/tokens/layer2-semantic.css
@@ -51,6 +51,29 @@
   --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px oklch(0 0 0 / 0.4);
   --shadow-lg: 0 10px 15px oklch(0 0 0 / 0.5);
+
+  /* Motion — semantic intent */
+  --motion-duration-fast: var(--sp-duration-100);
+  --motion-duration-normal: var(--sp-duration-150);
+  --motion-duration-slow: var(--sp-duration-300);
+  --motion-duration-entrance: var(--sp-duration-200);
+  --motion-duration-exit: var(--sp-duration-150);
+  --motion-ease: var(--sp-ease-default);
+  --motion-ease-entrance: var(--sp-ease-out);
+  --motion-ease-exit: var(--sp-ease-in);
+  --motion-ease-spring: var(--sp-ease-spring);
+}
+
+/* ── Reduced motion ────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --sp-duration-75: 0ms;
+    --sp-duration-100: 0ms;
+    --sp-duration-150: 0ms;
+    --sp-duration-200: 0ms;
+    --sp-duration-300: 0ms;
+    --sp-duration-500: 0ms;
+  }
 }
 
 /* ── Light mode ──────────────────────────────────────────────── */

--- a/src/tokens/layer3-component.css
+++ b/src/tokens/layer3-component.css
@@ -151,7 +151,8 @@
   /* Reuses --menu-* tokens */
 
   /* ── Collapsible ──────────────────────────────────────── */
-  /* No dedicated tokens — uses base animation utilities */
+  --collapsible-duration: var(--motion-duration-normal);
+  --collapsible-ease: var(--motion-ease);
 
   /* ── NavigationMenu ──────────────────────────────────── */
   /* Reuses --menu-* tokens */


### PR DESCRIPTION
## Summary
- Add 3-layer motion token architecture: primitive durations/easings → semantic intent → component-specific
- Add `usePrefersReducedMotion` hook for rAF-based JS animations (per ADR `global-css-motion-gate`)
- Add `@media (prefers-reduced-motion: reduce)` gate that zeros all duration tokens at Layer 1
- Replace hardcoded `duration-150/200/300` across 12 components with motion token references

## Motion Token Architecture
```
Layer 1 (Primitive):  --sp-duration-150, --sp-ease-default, --sp-ease-spring
Layer 2 (Semantic):   --motion-duration-normal, --motion-ease-entrance
Layer 3 (Component):  --collapsible-duration, --collapsible-ease
```

## Files Changed (18)
| Category | Files |
|----------|-------|
| Tokens | layer1-primitive.css, layer2-semantic.css, layer3-component.css |
| Hooks | usePrefersReducedMotion.ts, hooks/index.ts |
| Components | Button, Switch, Input, Checkbox, Textarea, Select, Slider, RadioGroup, Card, ProgressBar, Sidebar, Accordion, NavigationMenu |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` — 52/52 test files, 154/154 assertions pass
- [x] Zero hardcoded `duration-{n}` remaining in component source (`grep` verified)
- [ ] Visual verification: transitions work with motion tokens in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sprint 2/10 — Design System v1.0 Advancement