### PR TITLE
feat(demos): demo page schema + coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc -b",
-    "generate:llms": "node scripts/generate-llms-txt.js"
+    "generate:llms": "node scripts/generate-llms-txt.js",
+    "demo:coverage": "node scripts/demo-coverage.js"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",

--- a/scripts/demo-coverage.js
+++ b/scripts/demo-coverage.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Demo Coverage Report
+ *
+ * Reads the demo-schema.ts COMPONENT_CATALOG and demo-registry.ts
+ * to produce a coverage report showing which components are
+ * demonstrated and which are missing coverage.
+ *
+ * Usage: node scripts/demo-coverage.js
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+/* ── Parse catalog from demo-schema.ts ────────────────────────── */
+
+const schemaSource = readFileSync(
+  resolve(root, 'src/demos/demo-schema.ts'),
+  'utf-8',
+);
+
+// Extract all component names from the COMPONENT_CATALOG
+const catalogMatch = schemaSource.match(
+  /COMPONENT_CATALOG\s*=\s*\{([\s\S]*?)\}\s*as\s*const/,
+);
+if (!catalogMatch) {
+  console.error('Could not parse COMPONENT_CATALOG from demo-schema.ts');
+  process.exit(1);
+}
+
+function extractNames(block, key) {
+  const regex = new RegExp(`${key}:\\s*\\[([\\s\\S]*?)\\]`);
+  const match = block.match(regex);
+  if (!match) return [];
+  return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+const catalog = {
+  primitives: extractNames(catalogMatch[1], 'primitives'),
+  layout: extractNames(catalogMatch[1], 'layout'),
+  disclosure: extractNames(catalogMatch[1], 'disclosure'),
+  feedback: extractNames(catalogMatch[1], 'feedback'),
+};
+
+const allComponents = [
+  ...catalog.primitives,
+  ...catalog.layout,
+  ...catalog.disclosure,
+  ...catalog.feedback,
+];
+
+/* ── Parse registry from demo-registry.ts ─────────────────────── */
+
+const registrySource = readFileSync(
+  resolve(root, 'src/demos/demo-registry.ts'),
+  'utf-8',
+);
+
+// Extract component arrays from each demo entry
+const demoBlocks = [
+  ...registrySource.matchAll(
+    /id:\s*'([^']+)'[\s\S]*?components:\s*\{([\s\S]*?)\},\s*\n\s*layout:/g,
+  ),
+];
+
+const demos = demoBlocks.map((match) => {
+  const id = match[1];
+  const block = match[2];
+  return {
+    id,
+    primitives: extractNames(block, 'primitives'),
+    layout: extractNames(block, 'layout'),
+    disclosure: extractNames(block, 'disclosure'),
+    feedback: extractNames(block, 'feedback'),
+  };
+});
+
+/* ── Build coverage matrix ────────────────────────────────────── */
+
+const usedSet = new Set();
+const componentDemos = {}; // component -> demo IDs
+
+for (const demo of demos) {
+  const all = [
+    ...demo.primitives,
+    ...demo.layout,
+    ...demo.disclosure,
+    ...demo.feedback,
+  ];
+  for (const name of all) {
+    usedSet.add(name);
+    componentDemos[name] = componentDemos[name] || [];
+    componentDemos[name].push(demo.id);
+  }
+}
+
+const covered = allComponents.filter((c) => usedSet.has(c));
+const uncovered = allComponents.filter((c) => !usedSet.has(c));
+const pct = Math.round((covered.length / allComponents.length) * 100);
+
+/* ── Output ───────────────────────────────────────────────────── */
+
+console.log('');
+console.log('  Strata Demo Coverage Report');
+console.log('  ═══════════════════════════════════════════');
+console.log('');
+console.log(`  Total components:  ${allComponents.length}`);
+console.log(`  Covered:           ${covered.length} (${pct}%)`);
+console.log(`  Uncovered:         ${uncovered.length}`);
+console.log(`  Demos:             ${demos.length}`);
+console.log('');
+
+// Coverage by category
+for (const [cat, names] of Object.entries(catalog)) {
+  const catCovered = names.filter((n) => usedSet.has(n));
+  const catPct = Math.round((catCovered.length / names.length) * 100);
+  console.log(
+    `  ${cat.padEnd(12)} ${catCovered.length}/${names.length} (${catPct}%)`,
+  );
+}
+
+console.log('');
+console.log('  ── Uncovered Components ──');
+console.log('');
+
+for (const [cat, names] of Object.entries(catalog)) {
+  const missing = names.filter((n) => !usedSet.has(n));
+  if (missing.length > 0) {
+    console.log(`  ${cat}:`);
+    for (const name of missing) {
+      console.log(`    - ${name}`);
+    }
+  }
+}
+
+console.log('');
+console.log('  ── Component × Demo Matrix ──');
+console.log('');
+
+for (const name of covered.sort()) {
+  const demoList = (componentDemos[name] || []).join(', ');
+  console.log(`  ${name.padEnd(20)} ${demoList}`);
+}
+
+console.log('');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,15 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
-import { DiscordDemo } from '@/demos/discord/DiscordDemo';
-import { FigmaDemo } from '@/demos/figma/FigmaDemo';
-import { GitHubDemo } from '@/demos/github/GitHubDemo';
-import { LinearDemo } from '@/demos/linear/LinearDemo';
-import { NotionDemo } from '@/demos/notion/NotionDemo';
-import { SlackDemo } from '@/demos/slack/SlackDemo';
-import { SpotifyDemo } from '@/demos/spotify/SpotifyDemo';
-import { TwitterDemo } from '@/demos/twitter/TwitterDemo';
-import { TrelloDemo } from '@/demos/trello/TrelloDemo';
-import { VSCodeDemo } from '@/demos/vscode/VSCodeDemo';
-import { WhatsAppDemo } from '@/demos/whatsapp/WhatsAppDemo';
-import { RedditDemo } from '@/demos/reddit/RedditDemo';
-
-const DEMOS = {
-  linear: { label: 'Linear', component: LinearDemo },
-  slack: { label: 'Slack', component: SlackDemo },
-  twitter: { label: 'Twitter / X', component: TwitterDemo },
-  notion: { label: 'Notion', component: NotionDemo },
-  spotify: { label: 'Spotify', component: SpotifyDemo },
-  github: { label: 'GitHub', component: GitHubDemo },
-  discord: { label: 'Discord', component: DiscordDemo },
-  figma: { label: 'Figma', component: FigmaDemo },
-  vscode: { label: 'VS Code', component: VSCodeDemo },
-  trello: { label: 'Trello', component: TrelloDemo },
-  whatsapp: { label: 'WhatsApp', component: WhatsAppDemo },
-  reddit: { label: 'Reddit', component: RedditDemo },
-} as const;
-
-type DemoId = keyof typeof DEMOS;
+import { DEMO_REGISTRY } from '@/demos/demo-registry';
+import { computeCoverage } from '@/demos/demo-schema';
 
 export function App() {
-  const [active, setActive] = useState<DemoId>('linear');
-  const ActiveDemo = DEMOS[active].component;
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [showCoverage, setShowCoverage] = useState(false);
+
+  const active = DEMO_REGISTRY[activeIdx];
+  const ActiveDemo = active.component;
+  const coverage = useMemo(() => computeCoverage(DEMO_REGISTRY), []);
 
   return (
     <div className="flex h-screen flex-col">
@@ -41,26 +18,108 @@ export function App() {
         <span className="mr-3 text-xs font-semibold text-fg-subtle">
           Strata
         </span>
-        {(Object.entries(DEMOS) as [DemoId, (typeof DEMOS)[DemoId]][]).map(
-          ([id, { label }]) => (
-            <button
-              key={id}
-              onClick={() => setActive(id)}
-              className={cn(
-                'rounded-md px-3 py-1 text-xs font-medium transition-colors',
-                active === id
-                  ? 'bg-interactive-subtle text-interactive'
-                  : 'text-fg-muted hover:text-fg-default',
-              )}
-            >
-              {label}
-            </button>
-          ),
-        )}
+        {DEMO_REGISTRY.map((demo, idx) => (
+          <button
+            key={demo.id}
+            onClick={() => setActiveIdx(idx)}
+            className={cn(
+              'rounded-md px-3 py-1 text-xs font-medium transition-colors',
+              activeIdx === idx
+                ? 'bg-interactive-subtle text-interactive'
+                : 'text-fg-muted hover:text-fg-default',
+            )}
+          >
+            {demo.label}
+          </button>
+        ))}
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Coverage toggle */}
+        <button
+          onClick={() => setShowCoverage((v) => !v)}
+          className={cn(
+            'rounded-md px-2 py-1 text-[10px] font-mono transition-colors',
+            showCoverage
+              ? 'bg-interactive-subtle text-interactive'
+              : 'text-fg-subtle hover:text-fg-default',
+          )}
+        >
+          {coverage.percentage}% covered
+        </button>
       </div>
-      {/* Demo viewport */}
-      <div className="flex-1 overflow-hidden">
-        <ActiveDemo />
+
+      {/* Main area */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Demo viewport */}
+        <div className="flex-1 overflow-hidden">
+          <ActiveDemo />
+        </div>
+
+        {/* Coverage side panel */}
+        {showCoverage && (
+          <div className="w-72 shrink-0 overflow-y-auto border-l border-border-subtle bg-surface-raised p-3">
+            {/* Active demo info */}
+            <div className="mb-3">
+              <p className="text-xs font-semibold text-fg-default">
+                {active.label}
+              </p>
+              <p className="mt-0.5 text-[10px] text-fg-muted">
+                {active.description}
+              </p>
+              <p className="mt-1 text-[10px] text-fg-subtle">
+                Layout: {active.layout}
+              </p>
+            </div>
+
+            {/* Components used by active demo */}
+            <div className="mb-3 border-t border-border-subtle pt-2">
+              <p className="mb-1 text-[10px] font-semibold text-fg-muted">
+                Components used
+              </p>
+              {(
+                ['primitives', 'layout', 'disclosure', 'feedback'] as const
+              ).map(
+                (cat) =>
+                  active.components[cat].length > 0 && (
+                    <div key={cat} className="mb-1.5">
+                      <p className="text-[10px] font-medium text-fg-subtle capitalize">
+                        {cat}
+                      </p>
+                      <div className="flex flex-wrap gap-1 mt-0.5">
+                        {active.components[cat].map((name) => (
+                          <span
+                            key={name}
+                            className="rounded bg-interactive-subtle px-1.5 py-0.5 text-[10px] text-interactive"
+                          >
+                            {name}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ),
+              )}
+            </div>
+
+            {/* Global coverage */}
+            <div className="border-t border-border-subtle pt-2">
+              <p className="mb-1 text-[10px] font-semibold text-fg-muted">
+                Uncovered ({coverage.uncovered.length})
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {coverage.uncovered.map((name) => (
+                  <span
+                    key={name}
+                    className="rounded bg-danger-subtle px-1.5 py-0.5 text-[10px] text-danger"
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/demos/demo-registry.ts
+++ b/src/demos/demo-registry.ts
@@ -1,0 +1,207 @@
+/* ═══════════════════════════════════════════════════════════════
+   Demo Registry
+   Single source of truth for all demo pages.
+   Component lists are verified against actual imports.
+   ═══════════════════════════════════════════════════════════════ */
+
+import type { DemoSchema } from './demo-schema';
+import { DiscordDemo } from './discord/DiscordDemo';
+import { FigmaDemo } from './figma/FigmaDemo';
+import { GitHubDemo } from './github/GitHubDemo';
+import { LinearDemo } from './linear/LinearDemo';
+import { NotionDemo } from './notion/NotionDemo';
+import { RedditDemo } from './reddit/RedditDemo';
+import { SlackDemo } from './slack/SlackDemo';
+import { SpotifyDemo } from './spotify/SpotifyDemo';
+import { TrelloDemo } from './trello/TrelloDemo';
+import { TwitterDemo } from './twitter/TwitterDemo';
+import { VSCodeDemo } from './vscode/VSCodeDemo';
+import { WhatsAppDemo } from './whatsapp/WhatsAppDemo';
+
+/* ── Registry ─────────────────────────────────────────────────── */
+
+export const DEMO_REGISTRY: DemoSchema[] = [
+  {
+    id: 'linear',
+    label: 'Linear',
+    description: 'Project tracker with sidebar navigation and split-pane issue view.',
+    component: LinearDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Divider', 'Text'],
+      layout: ['AppShell', 'Sidebar', 'TopBar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'sidebar-detail',
+    features: { interactivity: true, density: true },
+  },
+  {
+    id: 'slack',
+    label: 'Slack',
+    description: 'Team messaging with workspace rail, channel sidebar, and compose area.',
+    component: SlackDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Divider', 'Input', 'Text'],
+      layout: ['Stack', 'TopBar', 'Sidebar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'three-column',
+    features: { interactivity: false, density: true },
+  },
+  {
+    id: 'twitter',
+    label: 'Twitter / X',
+    description: 'Social feed with left navigation, timeline, and trending sidebar.',
+    component: TwitterDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Input', 'Text'],
+      layout: ['Stack', 'TopBar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'three-column',
+    features: { interactivity: false, density: false },
+  },
+  {
+    id: 'notion',
+    label: 'Notion',
+    description: 'Document workspace with collapsible sidebar and block-based content.',
+    component: NotionDemo,
+    components: {
+      primitives: ['Button', 'Divider', 'Input', 'Text'],
+      layout: ['Sidebar', 'TopBar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'sidebar-main',
+    features: { interactivity: false, density: false },
+  },
+  {
+    id: 'spotify',
+    label: 'Spotify',
+    description: 'Music player with playlist sidebar, album grid, and fixed playback bar.',
+    component: SpotifyDemo,
+    components: {
+      primitives: ['Button', 'Text'],
+      layout: ['Sidebar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'fixed-footer',
+    features: { interactivity: true, density: false },
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    description: 'Repository view with file tree, code display, and action buttons.',
+    component: GitHubDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Divider', 'Input', 'Text'],
+      layout: ['TopBar'],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'sidebar-main',
+    features: { interactivity: false, density: false },
+  },
+  {
+    id: 'discord',
+    label: 'Discord',
+    description: 'Chat platform with server rail, channel list, messages, and member panel.',
+    component: DiscordDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Divider', 'Input', 'Text'],
+      layout: [],
+      disclosure: ['Tooltip'],
+      feedback: [],
+    },
+    layout: 'three-column',
+    features: { interactivity: false, density: false },
+  },
+  {
+    id: 'figma',
+    label: 'Figma',
+    description: 'Design tool with layers panel, canvas, and properties inspector.',
+    component: FigmaDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Divider', 'Input', 'Text'],
+      layout: [],
+      disclosure: ['Collapsible', 'Tooltip'],
+      feedback: [],
+    },
+    layout: 'three-column',
+    features: { interactivity: true, density: false },
+  },
+  {
+    id: 'vscode',
+    label: 'VS Code',
+    description: 'Code editor with activity bar, explorer sidebar, and tabbed editor.',
+    component: VSCodeDemo,
+    components: {
+      primitives: ['Badge', 'Divider', 'Text'],
+      layout: [],
+      disclosure: ['Collapsible', 'Tabs', 'Tooltip'],
+      feedback: [],
+    },
+    layout: 'sidebar-main',
+    features: { interactivity: true, density: false },
+  },
+  {
+    id: 'trello',
+    label: 'Trello',
+    description: 'Kanban board with draggable columns and task cards.',
+    component: TrelloDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Card', 'Text'],
+      layout: [],
+      disclosure: [],
+      feedback: [],
+    },
+    layout: 'kanban',
+    features: { interactivity: false, density: false },
+  },
+  {
+    id: 'whatsapp',
+    label: 'WhatsApp',
+    description: 'Mobile messaging with contact list and chat view in a phone frame.',
+    component: WhatsAppDemo,
+    components: {
+      primitives: ['Avatar', 'Badge', 'Button', 'Input', 'Text'],
+      layout: [],
+      disclosure: ['Tabs'],
+      feedback: [],
+    },
+    layout: 'mobile-frame',
+    features: { interactivity: true, density: false },
+  },
+  {
+    id: 'reddit',
+    label: 'Reddit',
+    description: 'Forum with subreddit sidebar, tabbed feed, and community info panel.',
+    component: RedditDemo,
+    components: {
+      primitives: [
+        'Avatar',
+        'Badge',
+        'Button',
+        'Card',
+        'Divider',
+        'Heading',
+        'Input',
+        'ScrollArea',
+        'Text',
+      ],
+      layout: ['Stack', 'TopBar'],
+      disclosure: ['Tabs'],
+      feedback: [],
+    },
+    layout: 'three-column',
+    features: { interactivity: false, density: false },
+  },
+];
+
+/** Lookup map for O(1) access by demo ID. */
+export const DEMO_MAP = Object.fromEntries(
+  DEMO_REGISTRY.map((d) => [d.id, d]),
+) as Record<string, DemoSchema>;

--- a/src/demos/demo-schema.ts
+++ b/src/demos/demo-schema.ts
@@ -1,0 +1,147 @@
+/* ═══════════════════════════════════════════════════════════════
+   Demo Page Schema
+   Typed metadata for each demo — drives the App.tsx registry,
+   component coverage reports, and llms.md generation.
+   ═══════════════════════════════════════════════════════════════ */
+
+import type { ComponentType } from 'react';
+
+/* ── Layout patterns ──────────────────────────────────────────── */
+
+export type LayoutPattern =
+  | 'sidebar-main' // 2-column: sidebar + main content
+  | 'sidebar-detail' // sidebar + list + detail panel
+  | 'three-column' // left nav + center + right widget
+  | 'kanban' // horizontal scrolling columns
+  | 'mobile-frame' // constrained mobile viewport
+  | 'fixed-footer'; // main content + fixed bottom bar
+
+/* ── Component catalog ────────────────────────────────────────── */
+
+/** All registered Strata components by category. */
+export const COMPONENT_CATALOG = {
+  primitives: [
+    'Avatar',
+    'AvatarGroup',
+    'Badge',
+    'Breadcrumb',
+    'Button',
+    'Card',
+    'Checkbox',
+    'Code',
+    'DataList',
+    'Divider',
+    'FormField',
+    'Heading',
+    'Input',
+    'Kbd',
+    'Label',
+    'Pagination',
+    'ProgressBar',
+    'RadioGroup',
+    'ScrollArea',
+    'Select',
+    'Separator',
+    'Slider',
+    'Spinner',
+    'StatusDot',
+    'Switch',
+    'Table',
+    'Text',
+    'Textarea',
+    'Toggle',
+    'ToggleGroup',
+    'Toolbar',
+    'Truncate',
+    'VisuallyHidden',
+  ],
+  layout: ['AppShell', 'Container', 'Sidebar', 'Stack', 'TopBar'],
+  disclosure: [
+    'Accordion',
+    'AlertDialog',
+    'Collapsible',
+    'ContextMenu',
+    'Dialog',
+    'DropdownMenu',
+    'HoverCard',
+    'Menubar',
+    'NavigationMenu',
+    'Popover',
+    'Sheet',
+    'Tabs',
+    'Tooltip',
+  ],
+  feedback: ['Alert', 'Callout', 'EmptyState', 'Skeleton', 'Toast'],
+} as const;
+
+export type ComponentCategory = keyof typeof COMPONENT_CATALOG;
+export type PrimitiveName = (typeof COMPONENT_CATALOG.primitives)[number];
+export type LayoutName = (typeof COMPONENT_CATALOG.layout)[number];
+export type DisclosureName = (typeof COMPONENT_CATALOG.disclosure)[number];
+export type FeedbackName = (typeof COMPONENT_CATALOG.feedback)[number];
+
+/* ── Demo schema ──────────────────────────────────────────────── */
+
+export interface DemoComponentMap {
+  primitives: PrimitiveName[];
+  layout: LayoutName[];
+  disclosure: DisclosureName[];
+  feedback: FeedbackName[];
+}
+
+export interface DemoSchema {
+  /** Unique identifier (kebab-case). */
+  id: string;
+  /** Display label. */
+  label: string;
+  /** One-line description of what the demo recreates. */
+  description: string;
+  /** The React component to render. */
+  component: ComponentType;
+  /** Strata components used in this demo. */
+  components: DemoComponentMap;
+  /** Layout pattern. */
+  layout: LayoutPattern;
+  /** Features demonstrated. */
+  features: {
+    /** Has interactive local state. */
+    interactivity: boolean;
+    /** Uses density-responsive tokens. */
+    density: boolean;
+  };
+}
+
+/* ── Coverage helpers ─────────────────────────────────────────── */
+
+export interface CoverageReport {
+  /** Total unique components across all demos. */
+  covered: string[];
+  /** Components that exist but have no demo coverage. */
+  uncovered: string[];
+  /** Coverage percentage. */
+  percentage: number;
+}
+
+/** Compute coverage report from a list of demo schemas. */
+export function computeCoverage(demos: DemoSchema[]): CoverageReport {
+  const allComponents = [
+    ...COMPONENT_CATALOG.primitives,
+    ...COMPONENT_CATALOG.layout,
+    ...COMPONENT_CATALOG.disclosure,
+    ...COMPONENT_CATALOG.feedback,
+  ];
+
+  const usedSet = new Set<string>();
+  for (const demo of demos) {
+    for (const name of demo.components.primitives) usedSet.add(name);
+    for (const name of demo.components.layout) usedSet.add(name);
+    for (const name of demo.components.disclosure) usedSet.add(name);
+    for (const name of demo.components.feedback) usedSet.add(name);
+  }
+
+  const covered = allComponents.filter((c) => usedSet.has(c));
+  const uncovered = allComponents.filter((c) => !usedSet.has(c));
+  const percentage = Math.round((covered.length / allComponents.length) * 100);
+
+  return { covered, uncovered, percentage };
+}


### PR DESCRIPTION
## Summary
- **DemoSchema type system**: Typed schema declaring component usage, layout patterns, and feature flags for each demo
- **DEMO_REGISTRY**: Single source of truth replacing the flat `DEMOS` object — all 12 demos annotated with metadata
- **Coverage panel**: Toggle in App.tsx top bar showing per-demo component list and global uncovered components
- **CLI coverage script**: `pnpm demo:coverage` reports coverage matrix (currently 29% — 16/56 components)

## Architecture
```
demo-schema.ts   → Type definitions + COMPONENT_CATALOG + computeCoverage()
demo-registry.ts → 12 DemoSchema entries with component annotations
App.tsx          → Consumes registry, renders coverage side panel
demo-coverage.js → Node script parsing schema/registry for CLI reporting
```

## Coverage Baseline
| Category | Covered | Total | % |
|----------|---------|-------|---|
| Primitives | 9 | 33 | 27% |
| Layout | 4 | 5 | 80% |
| Disclosure | 3 | 13 | 23% |
| Feedback | 0 | 5 | 0% |
| **Total** | **16** | **56** | **29%** |

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 154/154 tests pass
- [x] `pnpm demo:coverage` produces correct report
- [x] App.tsx renders demo switcher + coverage panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)