### PR TITLE
feat(a11y): focus tokens + FormField ARIA + focus-visible standardization

### DIFF
--- a/src/components/primitives/FormField/FormField.test.tsx
+++ b/src/components/primitives/FormField/FormField.test.tsx
@@ -14,13 +14,14 @@ describe('FormField', () => {
     expect(screen.getByTestId('input')).toBeInTheDocument();
   });
 
-  it('shows required indicator', () => {
+  it('shows required indicator with sr-only text', () => {
     render(
       <FormField label="Email" required>
         <input />
       </FormField>,
     );
-    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('(required)')).toHaveClass('sr-only');
   });
 
   it('shows description when no error', () => {
@@ -46,5 +47,43 @@ describe('FormField', () => {
     expect(
       screen.queryByText('Tell us about yourself.'),
     ).not.toBeInTheDocument();
+  });
+
+  it('error message has role="alert"', () => {
+    render(
+      <FormField label="Name" error="Required.">
+        <input />
+      </FormField>,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Required.');
+  });
+
+  it('auto-generates htmlFor linking label to input via render-prop', () => {
+    render(
+      <FormField label="Username">
+        {({ inputId }) => <input id={inputId} data-testid="linked-input" />}
+      </FormField>,
+    );
+    const input = screen.getByTestId('linked-input');
+    const label = screen.getByText('Username');
+    expect(label).toHaveAttribute('for', input.id);
+  });
+
+  it('provides aria-describedby IDs via render-prop', () => {
+    render(
+      <FormField label="Email" description="We won't share it." error="Invalid.">
+        {({ inputId, describedBy }) => (
+          <input
+            id={inputId}
+            aria-describedby={describedBy}
+            data-testid="described-input"
+          />
+        )}
+      </FormField>,
+    );
+    const input = screen.getByTestId('described-input');
+    const errorEl = screen.getByRole('alert');
+    // When error is present, describedBy should include the error ID
+    expect(input.getAttribute('aria-describedby')).toContain(errorEl.id);
   });
 });

--- a/src/components/primitives/FormField/FormField.tsx
+++ b/src/components/primitives/FormField/FormField.tsx
@@ -1,13 +1,24 @@
-import type { ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+
+/** IDs exposed to render-prop children for ARIA linking. */
+export interface FormFieldIds {
+  inputId: string;
+  descriptionId: string | undefined;
+  errorId: string | undefined;
+  /** Space-separated ID string for aria-describedby. */
+  describedBy: string | undefined;
+}
 
 interface FormFieldProps {
   label: string;
   description?: string;
   error?: string;
   required?: boolean;
+  /** Override the auto-generated input ID. */
   htmlFor?: string;
-  children: ReactNode;
+  /** Plain ReactNode or render-prop receiving auto-generated ARIA IDs. */
+  children: ReactNode | ((ids: FormFieldIds) => ReactNode);
   className?: string;
 }
 
@@ -20,22 +31,42 @@ export function FormField({
   children,
   className,
 }: FormFieldProps) {
+  const autoId = useId();
+  const inputId = htmlFor ?? autoId;
+  const descriptionId = description && !error ? `${inputId}-desc` : undefined;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const describedBy =
+    [descriptionId, errorId].filter(Boolean).join(' ') || undefined;
+
+  const ids: FormFieldIds = { inputId, descriptionId, errorId, describedBy };
+
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       {label && (
         <label
-          htmlFor={htmlFor}
+          htmlFor={inputId}
           className="text-sm font-medium text-fg-default"
         >
           {label}
-          {required && <span className="ml-1 text-danger">*</span>}
+          {required && (
+            <span className="ml-1 text-danger" aria-hidden="true">
+              *
+            </span>
+          )}
+          {required && <span className="sr-only"> (required)</span>}
         </label>
       )}
-      {children}
+      {typeof children === 'function' ? children(ids) : children}
       {description && !error && (
-        <p className="text-xs text-fg-muted">{description}</p>
+        <p id={descriptionId} className="text-xs text-fg-muted">
+          {description}
+        </p>
       )}
-      {error && <p className="text-xs text-danger">{error}</p>}
+      {error && (
+        <p id={errorId} className="text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -33,7 +33,7 @@ export function Input({
         'bg-[--input-bg] text-[--input-fg] border border-[--input-border]',
         'placeholder:text-[--input-placeholder]',
         'transition-colors duration-[--motion-duration-normal]',
-        'focus:outline-none focus:ring-2 focus:ring-[--input-ring] focus:border-[--input-border-focus]',
+        'focus-visible:outline-none focus-visible:ring-[length:--focus-ring-width] focus-visible:ring-[--focus-ring-color] focus-visible:ring-offset-[length:--focus-ring-offset] focus-visible:ring-offset-[--surface-base]',
         'disabled:pointer-events-none disabled:opacity-40',
         error && 'border-[--input-border-error]',
         SIZE_MAP[size],

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -35,7 +35,7 @@ export function SelectTrigger({
         'border border-[--select-border] bg-[--select-bg] px-[--density-padding-x] text-sm text-[--select-fg]',
         'placeholder:text-[--select-placeholder]',
         'transition-colors duration-[--motion-duration-normal]',
-        'focus:outline-none focus:ring-2 focus:ring-[--select-border-focus]',
+        'focus-visible:outline-none focus-visible:ring-[length:--focus-ring-width] focus-visible:ring-[--focus-ring-color] focus-visible:ring-offset-[length:--focus-ring-offset] focus-visible:ring-offset-[--surface-base]',
         'disabled:pointer-events-none disabled:opacity-40',
         className,
       )}

--- a/src/components/primitives/Textarea/Textarea.tsx
+++ b/src/components/primitives/Textarea/Textarea.tsx
@@ -36,7 +36,7 @@ export function Textarea({
         'bg-[--input-bg] text-[--input-fg] border border-[--input-border]',
         'placeholder:text-[--input-placeholder]',
         'transition-colors duration-[--motion-duration-normal]',
-        'focus:outline-none focus:ring-2 focus:ring-[--input-ring] focus:border-[--input-border-focus]',
+        'focus-visible:outline-none focus-visible:ring-[length:--focus-ring-width] focus-visible:ring-[--focus-ring-color] focus-visible:ring-offset-[length:--focus-ring-offset] focus-visible:ring-offset-[--surface-base]',
         'disabled:pointer-events-none disabled:opacity-40',
         'resize-y',
         error && 'border-[--input-border-error]',

--- a/src/tokens/layer2-semantic.css
+++ b/src/tokens/layer2-semantic.css
@@ -66,6 +66,11 @@
   --type-label: var(--sp-text-sm);
   --type-caption: var(--sp-text-xs);
 
+  /* Focus — accessible ring (WCAG 2.2 AA: 3:1 against adjacents) */
+  --focus-ring-color: var(--sp-blue-500);
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+
   /* Motion — semantic intent */
   --motion-duration-fast: var(--sp-duration-100);
   --motion-duration-normal: var(--sp-duration-150);
@@ -125,6 +130,8 @@
   --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.06);
   --shadow-md: 0 4px 6px oklch(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px oklch(0 0 0 / 0.15);
+
+  --focus-ring-color: var(--sp-blue-600);
 }
 
 /* ── Theme: Blue → purple accent (dark) ────────────────────── */


### PR DESCRIPTION
## Summary
- **Focus ring tokens**: New semantic tokens `--focus-ring-color`, `--focus-ring-width`, `--focus-ring-offset` in Layer 2 (dark + light mode variants)
- **focus-visible standardization**: Input, Textarea, Select migrated from `focus:` to `focus-visible:` — keyboard-only users see rings, mouse users don't
- **FormField ARIA redesign**: Auto-generated IDs via `useId()`, `aria-describedby` linking for error/description text, render-prop API for full ARIA control
- **Required indicator**: `aria-hidden="true"` on visual `*` + `.sr-only` "(required)" for screen readers
- **Error messages**: `role="alert"` on error `<p>` for live announcements

## Changes
| File | Change |
|------|--------|
| `layer2-semantic.css` | Focus ring tokens (dark + light) |
| `Input.tsx` | `focus:` → `focus-visible:` with token references |
| `Textarea.tsx` | Same focus standardization |
| `Select.tsx` | Same focus standardization |
| `FormField.tsx` | Auto-ID, `aria-describedby`, render-prop, `role="alert"` |
| `FormField.test.tsx` | 3 new a11y tests (7 total) |

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 157/157 tests pass (3 new)
- [x] FormField render-prop exposes `inputId`, `describedBy`, `descriptionId`, `errorId`
- [x] Error messages announce via `role="alert"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)